### PR TITLE
TargetFramework added for .NET 4.7.1

### DIFF
--- a/src/IpfsApi.csproj
+++ b/src/IpfsApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard14;netstandard2;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard14;netstandard2;net45;net471</TargetFrameworks>
     <AssemblyName>Ipfs.Api</AssemblyName>
     <RootNamespace>Ipfs.Api</RootNamespace>
     <DocumentationFile>Ipfs.Api.xml</DocumentationFile>
@@ -32,6 +32,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
 	<PackageReference Include="System.Net.Http" Version="4.3.3" Condition="'$(TargetFramework)' == 'netstandard14'" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" Condition="'$(TargetFramework)' == 'net45'" />
+    <Reference Include="System.Net" Condition="'$(TargetFramework)' == 'net471'" />
+    <Reference Include="System.Net.Http" Condition="'$(TargetFramework)' == 'net471'" />
   </ItemGroup>
  
 


### PR DESCRIPTION
References (framework + facade) added for System.Net, System.Net.Http

This is required because previously I only updated the references for .Net Standard 2 - In .NET 4.7.1 the facades and the framework now take care of System.Net.Http. This was apparently not the case in 4.7 and below, so a new TargetFramework needed to be added.